### PR TITLE
Постройте мелкие сетки на гридах для подходящих компонентов

### DIFF
--- a/catalog.html
+++ b/catalog.html
@@ -11,8 +11,8 @@
 
 	<!-- Начало хедера -->
 
-	<header class="page-header">
-		<div class="container">
+	<header class="page-header page-header-catalog">
+		<div class="page-header-container">
 			<h2 class="visually-hidden">Навигация</h2>
 			<a class="logo" href="/">
 				<img src="images/logo.svg" width="145px" height="36px" alt="Логотип сайта Device">
@@ -77,7 +77,7 @@
 
 	<main class="main-inner">
 		<div class="breadcrumbs-wrapper">
-			<div class="container">
+			<div class="inner-header-container">
 				<header>
 					<h1 class="inner-header-title">Моноподы для селфи</h1>
 
@@ -143,35 +143,35 @@
 						<ul class="catalog-filter-list">
 							<li class="catalog-filter-item">
 								<label class="control">
-									<input class="visually-hidden control-input" type="checkbox" name="black" checked>
+									<input class="control-input" type="checkbox" name="black" checked>
 									<span class="control-mark"></span>
 									<span class="control-label">Чёрный</span>
 								</label>
 							</li>
 							<li class="catalog-filter-item">
 								<label class="control">
-									<input class="visually-hidden control-input" type="checkbox" name="white" checked>
+									<input class="control-input" type="checkbox" name="white" checked>
 									<span class="control-mark"></span>
 									<span class="control-label">Белый</span>
 								</label>
 							</li>
 							<li class="catalog-filter-item">
 								<label class="control">
-									<input class="visually-hidden control-input" type="checkbox" name="blue">
+									<input class="control-input" type="checkbox" name="blue">
 									<span class="control-mark"></span>
 									<span class="control-label">Синий</span>
 								</label>
 							</li>
 							<li class="catalog-filter-item">
 								<label class="control">
-									<input class="visually-hidden control-input" type="checkbox" name="red">
+									<input class="control-input" type="checkbox" name="red">
 									<span class="control-mark"></span>
 									<span class="control-label">Красный</span>
 								</label>
 							</li>
 							<li class="catalog-filter-item">
 								<label class="control">
-									<input class="visually-hidden control-input" type="checkbox" name="pink">
+									<input class="control-input" type="checkbox" name="pink">
 									<span class="control-mark"></span>
 									<span class="control-label">Розовый</span>
 								</label>
@@ -183,14 +183,14 @@
 						<ul class="catalog-filter-list">
 							<li class="catalog-filter-item">
 								<label class="control">
-									<input class="visually-hidden control-input" type="radio" name="product-group" value="yes" checked>
+									<input class="control-input" type="radio" name="product-group" value="yes" checked>
 									<span class="control-mark"></span>
 									<span class="control-label">Есть</span>
 								</label>
 							</li>
 							<li class="catalog-filter-item">
 								<label class="control">
-									<input class="visually-hidden control-input" type="radio" name="product-group" value="no">
+									<input class="control-input" type="radio" name="product-group" value="no">
 									<span class="control-mark"></span>
 									<span class="control-label">Нет</span>
 								</label>
@@ -211,43 +211,51 @@
 									<img class="product-card-image" src="content/amateur-selfie-stick.jpg" width="360" height="380"
 										alt="Любительская селфи-палка">
 								</a>
-								<a class=" -link" href="#">
-									<h3 class="product-card-title">Любительская селфи-палка</h3>
-								</a>
-								<span class="product-card-price">500 ₽</span>
+								<div class="product-card-content">
+									<a class="product-card-title-link" href="#">
+										<h3 class="product-card-title">Любительская<br> селфи-палка</h3>
+									</a>
+									<span class="product-card-price">500 ₽</span>
+								</div>
 							</li>
 							<li class="product-card">
 								<a href="product.html" class="product-card-link">
 									<img class="product-card-image" src="content/professional-selfie-stick.jpg" width="360" height="380"
 										alt="Профессиональная селфи-палка">
 								</a>
-								<a class="product-card-title-link" href="#">
-									<h3 class="product-card-title">Профессиональная селфи-палка</h3>
-								</a>
-								<span class="product-card-price">1 500 ₽</span>
+								<div class="product-card-content">
+									<a class="product-card-title-link" href="#">
+										<h3 class="product-card-title">Профессиональная<br> селфи-палка</h3>
+									</a>
+									<span class="product-card-price">1 500 ₽</span>
+								</div>
 							</li>
 							<li class="product-card">
 								<a href="product.html" class="product-card-link">
 									<img class="product-card-image" src="content/unsinkable-selfie-stick.jpg" width="360" height="380"
 										alt="Непотопляемая селфи-палка">
 								</a>
-								<a class="product-card-title-link" href="#">
-									<h3 class="product-card-title">Непотопляемая селфи-палка</h3>
-								</a>
-								<span class="product-card-price">2 500 ₽</span>
+								<div class="product-card-content">
+									<a class="product-card-title-link" href="#">
+										<h3 class="product-card-title">Непотопляемая<br> селфи-палка</h3>
+									</a>
+									<span class="product-card-price">2 500 ₽</span>
+								</div>
 							</li>
 							<li class="product-card">
 								<a href="product.html" class="product-card-link">
 									<img class="product-card-image" src="content/follow-me-selfie-stick.jpg" width="360" height="380"
 										alt="Селфи-палка «Следуй за мной»">
 								</a>
-								<a class="product-card-title-link" href="#">
-									<h3 class="product-card-title">Селфи-палка «Следуй за мной»</h3>
-								</a>
-								<span class="product-card-price">1 500 ₽</span>
+								<div class="product-card-content">
+									<a class="product-card-title-link" href="#">
+										<h3 class="product-card-title">Селфи-палка «Следуй за<br> мной»</h3>
+									</a>
+									<span class="product-card-price">1 500 ₽</span>
+								</div>
 							</li>
+							<button class="button pagination-show-more" type="button">Загрузить ещё</button>
 						</ul>
-						<button class="button pagination-show-more" type="button">Загрузить ещё</button>
 
 						<!-- Конец каталога товаров -->
 

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 	<!-- Начало хедера -->
 
 	<header class="page-header">
-		<div class="container">
+		<div class="page-header-container">
 			<h2 class="visually-hidden">Навигация</h2>
 			<a class="logo" href="/">
 				<img src="images/logo.svg" width="145px" height="36px" alt="Логотип сайта Device">

--- a/styles/style.css
+++ b/styles/style.css
@@ -55,16 +55,26 @@ body {
 /* Хедер */
 
 .page-header {
-	padding: 0 60px;
 	margin: 40px auto;
 	background-color: #FFE17F;
 	color: #000000;
 	width: 1160px;
 }
 
+.page-header-container {
+	padding: 0 60px;
+}
+
 .logo {
 	display: block;
 	margin-top: -23px;
+	width: 145px;
+}
+
+.upper-menu {
+	margin-top: 30px;
+	display: flex;
+	align-items: center;
 }
 
 .search {
@@ -80,21 +90,24 @@ body {
 	padding: 0;
 	display: flex;
 	flex-wrap: wrap;
-	justify-content: flex-end;
-}
-
-.user-menu .navigation-item:nth-child(1) {
-	padding-right: 265px;
+	margin-left: 20px;
 }
 
 .navigation-item {
 	list-style: none;
 }
 
-.navigation-link {
-	padding-left: 60px;
+.user-menu .navigation-link {
 	color: inherit;
 	text-decoration: none;
+}
+
+.user-menu .navigation-item:nth-child(2) {
+	margin-left: 244px;
+}
+
+.user-menu .navigation-item:nth-child(3) {
+	margin-left: 60px;
 }
 
 .navigation-link-user {
@@ -108,17 +121,16 @@ body {
 	text-decoration: none;
 }
 
-.upper-menu {
-	margin-top: 30px;
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-}
-
 .navigation {
   margin: 0 auto;
 	margin-top: 30px;
 	padding-bottom: 136px;
+}
+
+.page-header-catalog .navigation {
+  margin: 0 auto;
+	margin-top: 30px;
+	padding-bottom: 38px;
 }
 
 .navigation-main {
@@ -168,6 +180,8 @@ body {
 	font-size: 18px;
 	line-height: 21px;
 	letter-spacing: 0.2em;
+	color: inherit;
+	text-decoration: none;
 }
 
 /* Слайдер */
@@ -256,7 +270,7 @@ body {
 	font-size: 36px;
 }
 
-td:nth-child(2) {
+.slider-advantages td:nth-child(2) {
 	padding-right: 200px;
 }
 
@@ -752,7 +766,10 @@ td:nth-child(2) {
 	padding-bottom: 36px;
 }
 
-.innner-header {
+.inner-header-container {
+	width: 1160px;
+	margin: 0 auto;
+	padding-left: 120px;
 }
 
 .inner-header-title {
@@ -795,10 +812,11 @@ td:nth-child(2) {
 	height: 70px;
 	width: 1160px;
 	margin: 0 auto;
+	padding-left: 120px;
 }
 
 .filter-title-wrapper {
-	width: 320px;
+	width: 300px;
 }
 
 .filter-title {
@@ -816,8 +834,7 @@ td:nth-child(2) {
 .sorting-wrapper {
 	display: flex;
 	justify-content: space-between;
-	width: 840px;
-	padding: 0 80px;
+	width: 760px;
 }
 
 .sorting-title {
@@ -904,13 +921,11 @@ td:nth-child(2) {
 	text-transform: uppercase;
 }
 
-/* Фильтр по центру */
+/* Каталог товаров */
 
 .catalog-right-column {
-	width: 840px;
-}
 
-/* Каталог товаров */
+}
 
 .products-wrapper {
 	background-color: #FFFFFF;
@@ -918,16 +933,30 @@ td:nth-child(2) {
 }
 
 .product-list {
+	display: grid;
+	grid-template-columns: 360px 360px;
+	justify-content: center;
+	gap: 40px;
 	list-style: none;
 	margin: 0;
 	padding: 0;
 }
 
 .product-card {
+	display: flex;
+	flex-direction: column;
+}
+
+.product-card-content {
+	display: flex;
+	justify-content: space-between;
+	margin-top: 32px;
+
 }
 .product-card-link {
 }
 .product-card-image {
+	object-fit: cover;
 }
 .product-card-title-link {
 	font-weight: 700;
@@ -936,9 +965,12 @@ td:nth-child(2) {
 	letter-spacing: -0.02em;
 	text-decoration: none;
 	color: #000000;
+
+	margin: 0;
 }
 .product-card-title {
 	font-size: 18px;
+	margin: 0;
 }
 .product-card-price {
 	line-height: 21px;
@@ -950,6 +982,13 @@ td:nth-child(2) {
 	font-weight: 800;
 	font-size: 16px;
 	line-height: 19px;
+	letter-spacing: 0.2em;
+	text-transform: uppercase;
+
+	width: 760px;
+	height: 55px;
+	background-color: #ffffff;
+	border: 3px solid #EBEBEB;
 }
 
 /* Пагинация */
@@ -957,6 +996,7 @@ td:nth-child(2) {
 .pagination-container {
 	display: flex;
 	padding: 44px 40px 78px 40px;
+	width: 760px;
 }
 
 .pagination {
@@ -968,7 +1008,6 @@ td:nth-child(2) {
 	margin: 0;
 	padding: 16px 25px;
 	width: 760px;
-
 }
 .pagination-item {
 }


### PR DESCRIPTION
Помимо сетки на гридах есть ещё некоторые правки по сайту.

В index.html:

– Переименовал класс конейтнера для хедера, поскольку заметил, что хедер изначально был сделан неверно — размеры были больше, чем в макете. Исправил.

В catalog.html:

– В хедере добавил второй класс. Заметил, что на странице каталога хедер по высоте меньше, чем на основной странице. Класс нужен был лишь для изменения внутренних отступов у класса .navigation.

– Убрал непонятно зачем добавленный visually-hidden на контролах.

– В названиях карточек добавил тег <br>, чтобы перенести текст в нужных местах. Как реализовать это иначе – не сообразил. Также контент карточек обернул в контейнеры для стилизации.

– Кнопку "загрузить ещё" решил запихать в список для удобной стилизации. Предполагаю, что это семантически не правильное решение.

---
:mortar_board: [Постройте мелкие сетки на гридах для подходящих компонентов](https://up.htmlacademy.ru/htmlcss/33/user/1867989/tasks/9)